### PR TITLE
Add setup commands to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This site is built with [Jekyll](https://jekyllrb.com/).
 
 * Install Jekyll. You can do so by running `gem install bundler jekyll`.
 * Run `git clone https://github.com/pythonindia/inpycon2019`.
+* Run `bundle install` to install all dependencies.
 * Run `jekyll serve`.
 * Visit `http://localhost:4000/2019/`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This site is built with [Jekyll](https://jekyllrb.com/).
 * Install Jekyll. You can do so by running `gem install bundler jekyll`.
 * Run `git clone https://github.com/pythonindia/inpycon2019`.
 * Run `bundle install` to install all dependencies.
-* Run `jekyll serve`.
+* Run `bundle exec jekyll serve`.
 * Visit `http://localhost:4000/2019/`.
 
 ### Contributing to the website


### PR DESCRIPTION
After following the setup instructions, I tried to run `jekyll serve`
```
/Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/spec_set.rb:87:in `block in materialize': Could not find minitest-5.11.3 in any of the sources (Bundler::GemNotFound)
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/spec_set.rb:81:in `map!'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/spec_set.rb:81:in `materialize'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/definition.rb:170:in `specs'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/definition.rb:237:in `specs_for'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/definition.rb:226:in `requested_specs'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:108:in `block in definition_method'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:20:in `setup'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler.rb:107:in `setup'
	from /Library/Ruby/Gems/2.3.0/gems/jekyll-3.8.5/lib/jekyll/plugin_manager.rb:50:in `require_from_bundler'
	from /Library/Ruby/Gems/2.3.0/gems/jekyll-3.8.5/exe/jekyll:11:in `<top (required)>'
	from /usr/local/bin/jekyll:22:in `load'
	from /usr/local/bin/jekyll:22:in `<main>'
```
I got the following error. 
After a little Googling, I did `bundle install`

Thereafter, I tried running `jekyll serve`again, but I got the following error
```
/Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:319:in `check_for_activated_spec!': You have already activated sass 3.7.4, but your Gemfile requires sass 3.7.3. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:31:in `block in setup'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/spec_set.rb:148:in `each'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/spec_set.rb:148:in `each'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:26:in `map'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler/runtime.rb:26:in `setup'
	from /Library/Ruby/Gems/2.3.0/gems/bundler-2.0.1/lib/bundler.rb:107:in `setup'
	from /Library/Ruby/Gems/2.3.0/gems/jekyll-3.8.5/lib/jekyll/plugin_manager.rb:50:in `require_from_bundler'
	from /Library/Ruby/Gems/2.3.0/gems/jekyll-3.8.5/exe/jekyll:11:in `<top (required)>'
	from /usr/local/bin/jekyll:22:in `load'
	from /usr/local/bin/jekyll:22:in `<main>'
```

Hence I did `bundle exec jekyll serve` as prompted as it worked perfectly. 

_Please excuse me in case I did not follow best practices_