### PR TITLE
Prevent page reload when clicking on sponsorship in navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -22,7 +22,7 @@
         <ul class="nav navbar-nav main-menu">
           <li {% if page.nav == 'index' %}class="current"{% endif %}><a href="/2019/">Home</a></li>
           <li><a href="/blog/">Blog</a></li>
-          <li><a href="/2019/index.html#sponsorship">Sponsorship</a></li>
+          <li><a href="/2019/#sponsorship">Sponsorship</a></li>
           <li class="dropdown">
             <a href="#" class="dropbtn">CFP&nbsp;&nbsp;{% include icons/down-arrow.svg %}</a>
             <div class="dropdown-content">


### PR DESCRIPTION
When people visit `in.pycon.org`, they are redirected to `in.pycon.org/2019/`. When they click on `Sponsorship` in the navbar, there is an unnecessary page load. This is because, the link to sponsorship in the navbar is `/2019/index.html#sponsorship`. This leads to a page transition even though both the pages are the same.