### PR TITLE
code-of-conduct: duplicates removed: report guide

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -6,32 +6,55 @@ bloglike: true
 nav: code-of-conduct
 ---
 
-PyCon India is a community organized conference intended for advocating the use and adoption
-of the Python programming language in India. It is also a platform for fostering networking
-and collaboration among the Python developer community in India.
+# Code Of Conduct
 
-We value the participation of every member of the Python community and want all attendees to
-have an enjoyable and rewarding experience. Accordingly, every attendee of the conference is
-expected to show respect and courtesy to every other attendee throughout the conference and at
-all conference related events, whether officially organized by PyCon India or not.
+## PyCon India 2019 - Code of Conduct
 
-To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and
-volunteers at PyCon India are required to conform to the following Code of Conduct. Organizers
-will enforce this code throughout the event.
+PyCon India is a community organized conference intended for advocating the use and adoption of the Python programming language in India. It is also a platform for fostering networking and collaboration among the Python developer community in India.
 
-## Short Version
+We value the participation of every member of the Python community and want all attendees to have an enjoyable and rewarding experience. Diversity is one of our biggest strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at PyCon India are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the event.
 
-PyCon India is dedicated to providing a harassment-free conference experience for everyone,
-regardless of age, gender, sexual orientation, physical appearance, disability, race, religion or
-employment. We don't tolerate harassment of attendees in any form.
 
-All communication should be appropriate for a professional audience, including people from many
-different backgrounds.
+
+### Where
+This Code of Conduct applies to the venue of PyCon India 2019 Conference, pre-event & post-event informal gatherings, related online forums and all conference related events, whether officially organized by PyCon India or not.
+
+
+### Aim
+PyCon India 2019 welcomes and is dedicated to providing a harassment-free conference experience for everyone, regardless of age, gender, sexual orientation, physical appearance, disability, neurotype, race, religion, political opinion, culture or employment. We don’t tolerate harassment of attendees in any form.
+
+We believe in the broad spectrum of individual and collective experience and in the inherent dignity of all people. We believe that amazing things happen when people from different worlds and world-views approach each other to create a conversation.
+
+### Be the best you can be
+* Be generous, sensitive, understanding and respectful to your fellow Pythonistas, staff and workers. 
+* Seek out newcomers and help them feel like they belong. 
+* Listen with empathy when someone has a different perspective. 
+* Talk to someone if you notice that something could be better. 
+* All communication should be appropriate for a professional audience, including people from many different backgrounds. 
+
+### Please refrain from
+
+* Offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion
+* Violent threats or language directed against another person.
+* Swearing, insults and discriminatory jokes and language.
+* Deliberate intimidation, stalking, following, harassing photography or recording
+* Sustained disruption of talks or other event
+* Posting sexually explicit or violent material. Sexual language or imagery is inappropriate for all aspects of the conference, including talks
+* Posting (or threatening to post) other people's personally identifying information ("doxing").
+* Personal insults, especially those using racist or sexist terms.
+* Unwelcome sexual attention or inappropriate physical contact.
+* Advocating for, or encouraging, any of the above behavior.
+* Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+
+
+We have zero tolerance on harassment of conference participants in any form, including, but not limited to the activities mentioned here.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
 
 ### Code for Speakers
 
-Sexual language or imagery is inappropriate for your talks or slides. Refrain from using sexist,
-racist or exclusionary language anywhere in your content.
+Sexual language or imagery is inappropriate for your talks or slides. Refrain from using sexist, racist or exclusionary language anywhere in your content.
 
 ### Code for Exhibitors and Sponsors
 
@@ -39,64 +62,78 @@ Exhibitors in the expo hall, sponsor or vendor booths, are subject to the anti-h
 
 Exhibitors should not use sexualized images, activities, or other material.
 
-Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise
-create a sexualized environment.
+Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
 
 ### Code for Participants
 
-Be kind and sensitive to the people around you and avoid any kind of offensive behavior. Sexist,
-racist or any other form of exclusionary or offensive jokes or excessive public swearing are not
-appropriate at any venue of PyCon India.
+Be kind and sensitive to the people around you and avoid any kind of offensive behavior. Sexist, racist or any other form of exclusionary or offensive jokes or excessive public swearing are not appropriate at any venue of PyCon India.
 
-Attendees violating these rules may be asked to leave the conference without a refund at the sole
-discretion of the conference organizers.
 
-Thank you for your consideration and help in making PyCon India a welcoming, friendly event for all of us.
+## Reporting Guide
 
-## Long Version
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing “PyCon India Staff” or “PyCon India Volunteer” badges.
 
-PyCon India is dedicated to providing a harassment-free conference experience for everyone, regardless of age,
-gender, sexual orientation, physical appearance, disability, race, religion or employment.
+All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
 
-Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance,
-body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following,
-harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact,
-and unwelcome sexual attention. We have zero tolerance on harassment of conference participants in any form, including,
-but not limited to the activities mentioned here.
+If you believe anyone is in physical danger, please notify appropriate law enforcement first. If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
 
-Participants asked to stop any harassing behavior are expected to comply immediately.
+If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations, or happen outside our spaces, can also help us to improve the Code of Conduct or the processes surrounding it.
 
-Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment
-policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff
-(including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+### In your report please include:
 
-All communication should be appropriate for a professional audience, including people from many different backgrounds.
-Sexual language or imagery is inappropriate for all aspects of the conference, including talks. Remember that sexist,
-racist or any other form of exclusionary or offensive jokes or excessive public swearing are not appropriate at any
-venue of PyCon India.
+*    Your contact info (so we can get in touch with you if we need to follow up)
+*    Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+*    When and where the incident occurred. Please be as specific as possible.
+*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
+*   Any extra context you believe existed for the incident.
+*    If you believe this incident is ongoing.
+*    Any other information you believe we should have.
 
-Do not insult or put down attendees or engage in any action that violates the open, welcoming and sharing spirit of
-the conference. Be kind and sensitive to the people around you when you are attending the conference, and avoid any
-kind of offensive or degrading behavior.
+### What happens after you file a report?
 
-If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action
-they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+The working group will immediately meet to review the incident and determine:
+
+*    What happened.
+*    Whether this event constitutes a code of conduct violation.
+*    Who the bad actor was.
+*    Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+
+Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the staff's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
+
+ *   Nothing (if we determine no violation occurred).
+ *   A private reprimand from the working group to the individual(s) involved.
+ *   A public reprimand.
+ *   Expulsion from the conference with no refund.
+ *   A permanent or temporary ban from some or all PyCon India spaces (mailing lists, IRC, etc.)
+ *   A request for a public or private apology.
+
+We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
+
+Finally, the PyCon India Staff will make a report on the situation.
+
+What if your report concerns a possible violation by a staff member?
+
+
+In that case, you can make a report directly to any or all of the current (vice/co) chairs of the Code of Conduct committee. Their e-mail addresses are listed on the Code of Conduct Committee page. The chairs will follow the usual enforcement process with the other members, but will exclude the member(s) that the report concerns from any discussion or decision making.
+
+If your report concerns all current (vice/co) chairs of the committee, please send your report directly to the PSF Board of Directors at  psf@python.org instead.
 
 Thank you for helping to make PyCon India a welcoming, friendly event for all.
 
 ## Contact Information
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a
-member of conference staff. Conference staff will be wearing "PyCon India Staff" or "PyCon India Volunteer" badges.
-
-Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts,
-or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
-
 If the matter is especially urgent, you may also ask to be put in touch with the conference chair - Vijay Kumar
 
 ## License
 
-This Code of Conduct was forked from PSF Code of Conduct by Python Software Foundation which is under a Creative
-Commons Attribution 3.0 Unported License.
+This Code of Conduct was forked from 
+1. PSF Code of Conduct by Python Software Foundation which is under a Creative Commons Attribution 3.0 Unported License 
+2. "Django Code of Conduct - Reporting Guide" by Django Software Foundation which is under a Creative Commons Attribution license.
 
 PyCon India Conference Code of Conduct is licensed under a Creative Commons Attribution 3.0 Unported License.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -6,7 +6,6 @@ bloglike: true
 nav: code-of-conduct
 ---
 
-# Code Of Conduct
 ## The Short Form
 We invite you to come to PyCon India 2019 in a spirit of curiosity, friendliness, open-mindedness, and respect. We will not tolerate harassment in any form.
 
@@ -29,6 +28,8 @@ We value the participation of every member of the Python community and want all 
 ### Where
 This Code of Conduct applies to the venue of PyCon India 2019 Conference, pre-event & post-event informal gatherings, related online forums and all conference related events, whether officially organized by PyCon India or not.
 
+### Who
+This is applicable to speakers, participants, exhibitors, sponsors and all other attendees.
 
 ### Aim
 PyCon India 2019 welcomes and is dedicated to providing a harassment-free conference experience for everyone, regardless of age, gender, sexual orientation, physical appearance, disability, neurotype, race, religion, political opinion, culture or employment. We don’t tolerate harassment of attendees in any form.
@@ -46,46 +47,28 @@ We believe in the broad spectrum of individual and collective experience and in 
 
 * Offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion
 * Violent threats or language directed against another person.
-* Swearing, insults and discriminatory jokes and language.
+* Swearing, insults or discriminatory/exclusionary/offensive jokes or language.
 * Deliberate intimidation, stalking, following, harassing photography or recording
 * Sustained disruption of talks or other event
-* Posting sexually explicit or violent material. Sexual language or imagery is inappropriate for all aspects of the conference, including talks
+* Posting sexually explicit or violent material. Sexual language or imagery is inappropriate for all aspects of the conference, including talks and exhibits.
 * Posting (or threatening to post) other people's personally identifying information ("doxing").
 * Personal insults, especially those using racist or sexist terms.
 * Unwelcome sexual attention or inappropriate physical contact.
 * Advocating for, or encouraging, any of the above behavior.
 * Repeated harassment of others. In general, if someone asks you to stop, then stop.
-
-
+* Avoid use of sexuaalized clothing/uniforms/costumes, or otherwise create a sexualized environment.
 
 We have zero tolerance on harassment of conference participants in any form, including, but not limited to the activities mentioned here.
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
-### Code for Speakers
-
-Sexual language or imagery is inappropriate for your talks or slides. Refrain from using sexist, racist or exclusionary language anywhere in your content.
-
-### Code for Exhibitors and Sponsors
-
-Exhibitors in the expo hall, sponsor or vendor booths, are subject to the anti-harassment policy.
-
-Exhibitors should not use sexualized images, activities, or other material.
-
-Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
-
-### Code for Participants
-
-Be kind and sensitive to the people around you and avoid any kind of offensive behavior. Sexist, racist or any other form of exclusionary or offensive jokes or excessive public swearing are not appropriate at any venue of PyCon India.
-
-
 ## Reporting Guide
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing “PyCon India Staff” or “PyCon India Volunteer” badges. The detailed instructions on how reporting of violations will be handled and the steps for resolution, please check the <a href="https://in.pycon.org/2019/reporting-guide.html"> Reporting Guide</a>.
 
-## Contact Information
+### Contact Information
 
-If the matter is especially urgent, you may also ask to be put in touch with the conference chair - Vijay Kumar
+In case you are not able to locate a conference staff or you would prefer to report over email, please send your repors to report@in.pycon.org. We will also post a direct phone number shortly. If the matter is especially urgent, you may also ask to be put in touch with the diversity chair - Sharmila Gopirajan
 
 ## License
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,8 +7,18 @@ nav: code-of-conduct
 ---
 
 # Code Of Conduct
+## The Short Form
+We invite you to come to PyCon India 2019 in a spirit of curiosity, friendliness, open-mindedness, and respect. We will not tolerate harassment in any form.
 
-## PyCon India 2019 - Code of Conduct
+At the PyCon India venue and related online forums, you agree to:
+
+- Be kind and sensitive to the people around you and respect the boundaries of other attendees.
+- Attempt to resolve difference of opinions peacefully
+- Avoid harassment, exclusionary or offensive behaviour of any kind. This includes but is not limited to offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. 
+
+More information on <a href="https://in.pycon.org/2019/code-of-conduct.html"> Code of Conduct </a> and <a href="https://in.pycon.org/2019/reporting-guide.html"> Reporting Guide and Steps for Resolution</a>.
+
+## The Long Form
 
 PyCon India is a community organized conference intended for advocating the use and adoption of the Python programming language in India. It is also a platform for fostering networking and collaboration among the Python developer community in India.
 
@@ -71,60 +81,7 @@ Be kind and sensitive to the people around you and avoid any kind of offensive b
 
 ## Reporting Guide
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing “PyCon India Staff” or “PyCon India Volunteer” badges.
-
-All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
-
-If you believe anyone is in physical danger, please notify appropriate law enforcement first. If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
-
-If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations, or happen outside our spaces, can also help us to improve the Code of Conduct or the processes surrounding it.
-
-### In your report please include:
-
-*    Your contact info (so we can get in touch with you if we need to follow up)
-*    Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
-*    When and where the incident occurred. Please be as specific as possible.
-*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
-*   Any extra context you believe existed for the incident.
-*    If you believe this incident is ongoing.
-*    Any other information you believe we should have.
-
-### What happens after you file a report?
-
-The working group will immediately meet to review the incident and determine:
-
-*    What happened.
-*    Whether this event constitutes a code of conduct violation.
-*    Who the bad actor was.
-*    Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
-
-Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
-
-If this is determined to be an ongoing incident or a threat to physical safety, the staff's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
-
-Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
-
- *   Nothing (if we determine no violation occurred).
- *   A private reprimand from the working group to the individual(s) involved.
- *   A public reprimand.
- *   Expulsion from the conference with no refund.
- *   A permanent or temporary ban from some or all PyCon India spaces (mailing lists, IRC, etc.)
- *   A request for a public or private apology.
-
-We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
-
-Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
-
-Finally, the PyCon India Staff will make a report on the situation.
-
-What if your report concerns a possible violation by a staff member?
-
-
-In that case, you can make a report directly to any or all of the current (vice/co) chairs of the Code of Conduct committee. Their e-mail addresses are listed on the Code of Conduct Committee page. The chairs will follow the usual enforcement process with the other members, but will exclude the member(s) that the report concerns from any discussion or decision making.
-
-If your report concerns all current (vice/co) chairs of the committee, please send your report directly to the PSF Board of Directors at  psf@python.org instead.
-
-Thank you for helping to make PyCon India a welcoming, friendly event for all.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing “PyCon India Staff” or “PyCon India Volunteer” badges. The detailed instructions on how reporting of violations will be handled and the steps for resolution, please check the <a href="https://in.pycon.org/2019/reporting-guide.html"> Reporting Guide</a>.
 
 ## Contact Information
 
@@ -132,8 +89,6 @@ If the matter is especially urgent, you may also ask to be put in touch with the
 
 ## License
 
-This Code of Conduct was forked from 
-1. PSF Code of Conduct by Python Software Foundation which is under a Creative Commons Attribution 3.0 Unported License 
-2. "Django Code of Conduct - Reporting Guide" by Django Software Foundation which is under a Creative Commons Attribution license.
+This Code of Conduct was forked from PSF Code of Conduct by Python Software Foundation which is under a Creative Commons Attribution 3.0 Unported License 
 
 PyCon India Conference Code of Conduct is licensed under a Creative Commons Attribution 3.0 Unported License.

--- a/reporting-guide.md
+++ b/reporting-guide.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: Reporting Guide
+header: Reporting Guide
+bloglike: true
+nav: reporting-guide
+---
+
+# Reporting Guide
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing “PyCon India Staff” or “PyCon India Volunteer” badges.
+
+All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+If you believe anyone is in physical danger, please notify appropriate law enforcement first. If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
+
+If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations, or happen outside our spaces, can also help us to improve the Code of Conduct or the processes surrounding it.
+
+### In your report please include:
+
+*    Your contact info (so we can get in touch with you if we need to follow up)
+*    Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+*    When and where the incident occurred. Please be as specific as possible.
+*   Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
+*   Any extra context you believe existed for the incident.
+*    If you believe this incident is ongoing.
+*    Any other information you believe we should have.
+
+### What happens after you file a report?
+
+The working group will immediately meet to review the incident and determine:
+
+*    What happened.
+*    Whether this event constitutes a code of conduct violation.
+*    Who the bad actor was.
+*    Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+
+Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the staff's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
+
+ *   Nothing (if we determine no violation occurred).
+ *   A private reprimand from the working group to the individual(s) involved.
+ *   A public reprimand.
+ *   Expulsion from the conference with no refund.
+ *   A permanent or temporary ban from some or all PyCon India spaces (mailing lists, IRC, etc.)
+ *   A request for a public or private apology.
+
+We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
+
+Finally, the PyCon India Staff will make a report on the situation.
+
+What if your report concerns a possible violation by a staff member?
+
+
+In that case, you can make a report directly to any or all of the current (vice/co) chairs of the Code of Conduct committee. Their e-mail addresses are listed on the Code of Conduct Committee page. The chairs will follow the usual enforcement process with the other members, but will exclude the member(s) that the report concerns from any discussion or decision making.
+
+If your report concerns all current (vice/co) chairs of the committee, please send your report directly to the PSF Board of Directors at  psf@python.org instead.
+
+Thank you for helping to make PyCon India a welcoming, friendly event for all.
+
+## Contact Information
+
+If the matter is especially urgent, you may also ask to be put in touch with the conference chair - Vijay Kumar
+
+## License
+
+This Reporting guide was forked "Django Code of Conduct - Reporting Guide" by Django Software Foundation which is under a Creative Commons Attribution license.
+
+PyCon India Conference Reporting Guide is licensed under a Creative Commons Attribution 3.0 Unported License.


### PR DESCRIPTION
Removed duplicate content, adding a clear reporting guide, and hopefully a better flow.